### PR TITLE
feat: bonus features filter status..

### DIFF
--- a/cmd/add_log.go
+++ b/cmd/add_log.go
@@ -1,0 +1,89 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/axellelanca/go_loganizer/internal/config"
+)
+
+var (
+	addLogConfigPath string
+	addLogID        string
+	addLogPath      string
+	addLogType      string
+)
+
+var addLogCmd = &cobra.Command{
+	Use:   "add-log",
+	Short: "Ajoute une nouvelle configuration de log au fichier config.json",
+	Long: `La commande add-log permet d'ajouter manuellement une nouvelle configuration
+de log au fichier config.json existant.
+
+Exemples:
+  # Ajouter une nouvelle configuration de log
+  loganalyzer add-log --file config.json --id "new-log" --path "/var/log/new.log" --type "nginx"
+
+  # Utiliser les raccourcis
+  loganalyzer add-log -f config.json -i "new-log" -p "/var/log/new.log" -t "nginx"`,
+	RunE: runAddLog,
+}
+
+func init() {
+	rootCmd.AddCommand(addLogCmd)
+
+	addLogCmd.Flags().StringVarP(&addLogConfigPath, "file", "f", "", "Chemin vers le fichier de configuration JSON (requis)")
+	addLogCmd.Flags().StringVarP(&addLogID, "id", "i", "", "Identifiant unique du log (requis)")
+	addLogCmd.Flags().StringVarP(&addLogPath, "path", "p", "", "Chemin vers le fichier de log (requis)")
+	addLogCmd.Flags().StringVarP(&addLogType, "type", "t", "", "Type de log (requis)")
+
+	addLogCmd.MarkFlagRequired("file")
+	addLogCmd.MarkFlagRequired("id")
+	addLogCmd.MarkFlagRequired("path")
+	addLogCmd.MarkFlagRequired("type")
+}
+
+func runAddLog(cmd *cobra.Command, args []string) error {
+	// Load existing config
+	cfg, err := config.LoadConfig(addLogConfigPath)
+	if err != nil {
+		return fmt.Errorf("erreur lors du chargement de la configuration: %w", err)
+	}
+
+	// Check if log ID already exists
+	for _, log := range cfg.Logs {
+		if log.ID == addLogID {
+			return fmt.Errorf("un log avec l'ID '%s' existe déjà", addLogID)
+		}
+	}
+
+	// Create new log configuration
+	newLog := config.LogConfig{
+		ID:   addLogID,
+		Path: addLogPath,
+		Type: addLogType,
+	}
+
+	// Add new log to configuration
+	cfg.Logs = append(cfg.Logs, newLog)
+
+	// Write updated config back to file
+	jsonData, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		return fmt.Errorf("erreur lors de la sérialisation JSON: %w", err)
+	}
+
+	if err := os.WriteFile(addLogConfigPath, jsonData, 0644); err != nil {
+		return fmt.Errorf("erreur lors de l'écriture du fichier %s: %w", addLogConfigPath, err)
+	}
+
+	fmt.Printf("✅ Nouvelle configuration de log ajoutée avec succès:\n")
+	fmt.Printf("   ID: %s\n", newLog.ID)
+	fmt.Printf("   Chemin: %s\n", newLog.Path)
+	fmt.Printf("   Type: %s\n", newLog.Type)
+
+	return nil
+} 

--- a/cmd/analyze.go
+++ b/cmd/analyze.go
@@ -3,6 +3,8 @@ package cmd
 import (
 	"fmt"
 	"math/rand"
+	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -15,6 +17,7 @@ import (
 var (
 	configPath string
 	outputPath string
+	statusFilter string
 )
 
 var analyzeCmd = &cobra.Command{
@@ -33,8 +36,11 @@ Exemples:
   # Analyser et exporter vers un fichier JSON
   loganalyzer analyze --config config.json --output report.json
 
+  # Filtrer par statut
+  loganalyzer analyze --config config.json --status FAILED
+
   # Utiliser les raccourcis
-  loganalyzer analyze -c config.json -o report.json`,
+  loganalyzer analyze -c config.json -o report.json -s FAILED`,
 	RunE: runAnalyze,
 }
 
@@ -43,6 +49,7 @@ func init() {
 
 	analyzeCmd.Flags().StringVarP(&configPath, "config", "c", "", "Chemin vers le fichier de configuration JSON (requis)")
 	analyzeCmd.Flags().StringVarP(&outputPath, "output", "o", "", "Chemin vers le fichier de sortie JSON (optionnel)")
+	analyzeCmd.Flags().StringVarP(&statusFilter, "status", "s", "", "Filtrer les résultats par statut (ex: FAILED, OK)")
 
 	analyzeCmd.MarkFlagRequired("config")
 }
@@ -63,6 +70,14 @@ func runAnalyze(cmd *cobra.Command, args []string) error {
 	var rep *reporter.Reporter
 	if outputPath != "" {
 		rep = reporter.NewReporter()
+		// Add timestamp to output filename
+		dir := filepath.Dir(outputPath)
+		base := filepath.Base(outputPath)
+		ext := filepath.Ext(base)
+		name := strings.TrimSuffix(base, ext)
+		timestamp := time.Now().Format("060102") // YYMMDD format
+		outputPath = filepath.Join(dir, fmt.Sprintf("%s_%s%s", timestamp, name, ext))
+		
 		if err := rep.ValidateOutputPath(outputPath); err != nil {
 			return fmt.Errorf("chemin de sortie invalide: %w", err)
 		}
@@ -75,6 +90,17 @@ func runAnalyze(cmd *cobra.Command, args []string) error {
 	startTime := time.Now()
 	results := logAnalyzer.AnalyzeLogs(cfg.Logs)
 	duration := time.Since(startTime)
+
+	// Filter results if status filter is provided
+	if statusFilter != "" {
+		filteredResults := make([]analyzer.AnalysisResult, 0)
+		for _, result := range results {
+			if result.Status == statusFilter {
+				filteredResults = append(filteredResults, result)
+			}
+		}
+		results = filteredResults
+	}
 
 	analyzer.PrintResults(results)
 


### PR DESCRIPTION
Did this:

🎁 BONUS
Vous avez l'âme d'un.e développeur.euse courageux.euse ? Je vous laisse ici quelques bonus si vous voulez vous amuser un peu et avoir un programme plus complet.

**1. Gestion des dossiers d'exportation **

Si le chemin de sortie JSON (--output) inclut des répertoires qui n'existent pas (ex: rapports/2024/mon_rapport.json), faire en sorte que le programme crée automatiquement ces répertoires avant d'écrire le fichier.
Indice : os.MkdirAll(filepath.Dir(path), 0755)
Intérêt : Rend l'outil plus robuste et convivial.

2. Horodatage des Exports JSON

Nommer les fichiers de sortie JSON avec une date :
Modifier la commande analyze pour que, si le drapeau --output est fourni, le nom du fichier de sortie JSON inclue la date du jour au format AAMMJJ (AnnéeMoisJour).
Exemple : au lieu de report.json, le fichier serait nommé 240524_report.json (pour le 24 mai 2024).
Indice : Utiliser le package time de Go (time.Now(), time.Format()).
Intérêt : Ajoute une fonctionnalité pratique pour l'organisation des rapports, et force à manipuler les dates en Go.

2. Commande add-log

Ajouter une nouvelle sous-commande add-log qui permettrait d'ajouter manuellement une configuration de log au fichier config.json existant.
Drapeaux nécessaires : --id, --path, --type, --file (chemin du fichier config.json).

3. Filtrage des résultats d'analyse

Ajouter un drapeau --status <status> (ex: --status FAILED ou --status OK) à la commande analyze pour n'afficher et/ou n'exporter que les logs ayant un certain statut.
Intérêt : Ajoute une fonctionnalité utile et demande de la logique de filtrage avant l'affichage/l'export.
